### PR TITLE
Add explicit types to avoid compile errors

### DIFF
--- a/ProfilerDataExporter.cs
+++ b/ProfilerDataExporter.cs
@@ -86,7 +86,7 @@ namespace ProfilerDataExporter
             {
                 var statsCalculator = StatsCalculatorProvider.GetStatsCalculator(statsType);
                 var stats = statsCalculator.CalculateStats(ColumnsToShow);
-                functionStats = stats.Select(f => ColumnsToShow.Select(f.GetValue).ToArray()).ToArray();
+                functionStats = stats.Select<FunctionData, string[]>(f => ColumnsToShow.Select<ProfilerColumn, string>(f.GetValue).ToArray()).ToArray();
             }
 
             if (functionStatsTableState == null)

--- a/StatsCalculator/StatsCalculatorBase.cs
+++ b/StatsCalculator/StatsCalculatorBase.cs
@@ -51,7 +51,7 @@ namespace ProfilerDataExporter
 
             var functionStats =
                 groupedFunctionData
-                    .Select(AggregateFunction)
+                    .Select<IGrouping<string, FunctionData>, FunctionData>(AggregateFunction)
                     .OrderByDescending(GetSelfTime)
                     .ToArray();
             return functionStats;


### PR DESCRIPTION
error CS0411: The type arguments for method

        `System.Linq.Enumerable.Select<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource, int, TResult>)'

cannot be inferred from the usage. Try specifying the type arguments explicitly