### PR TITLE
Adding parsing and type checks in SplitterState.cs

### DIFF
--- a/Allocators/IAllocator.cs
+++ b/Allocators/IAllocator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -9,4 +10,4 @@ namespace ProfilerDataExporter
         void Free(IList<T> elements);
     }
 }
-
+#endif

--- a/Allocators/ListPool.cs
+++ b/Allocators/ListPool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 
 namespace ProfilerDataExporter
@@ -17,4 +18,4 @@ namespace ProfilerDataExporter
         }
     }
 }
-
+#endif

--- a/Allocators/ObjectPool.cs
+++ b/Allocators/ObjectPool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 
 namespace ProfilerDataExporter
@@ -57,4 +58,4 @@ namespace ProfilerDataExporter
         }
     }
 }
-
+#endif

--- a/Factories/BaseFactory.cs
+++ b/Factories/BaseFactory.cs
@@ -1,4 +1,5 @@
-﻿namespace ProfilerDataExporter
+﻿#if UNITY_EDITOR
+namespace ProfilerDataExporter
 {
     public class BaseFactory<T> : IFactory<T>
         where T : new()
@@ -10,4 +11,4 @@
         }
     }
 }
-
+#endif

--- a/Factories/IFactory.cs
+++ b/Factories/IFactory.cs
@@ -1,8 +1,9 @@
-﻿namespace ProfilerDataExporter
+﻿#if UNITY_EDITOR
+namespace ProfilerDataExporter
 {
     public interface IFactory<T>
     {
         T Create();
     }
 }
-
+#endif

--- a/Factories/ListFactory.cs
+++ b/Factories/ListFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 
 namespace ProfilerDataExporter
@@ -28,4 +29,4 @@ namespace ProfilerDataExporter
         }
     }
 }
-
+#endif

--- a/FunctionTableState.cs
+++ b/FunctionTableState.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 #if !UNITY_2019_1_OR_NEWER
 using UnityEditorInternal.Profiling;
 #endif
@@ -70,3 +71,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/ProfilerData.cs
+++ b/ProfilerData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using UnityEditorInternal;
 #if !UNITY_2019_1_OR_NEWER
@@ -197,3 +198,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/ProfilerDataExporter.cs
+++ b/ProfilerDataExporter.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
 #if !UNITY_2019_1_OR_NEWER
@@ -268,5 +269,5 @@ namespace ProfilerDataExporter
             profilerData.Clear();
         }
     }
-
-}
+}   
+#endif  

--- a/StatsCalculator/AvgStatsCalculator.cs
+++ b/StatsCalculator/AvgStatsCalculator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -15,3 +16,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/StatsCalculator/MaxStatsCalculator.cs
+++ b/StatsCalculator/MaxStatsCalculator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -19,3 +20,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/StatsCalculator/MinStatsCalculator.cs
+++ b/StatsCalculator/MinStatsCalculator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -19,3 +20,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/StatsCalculator/StatsCalculatorBase.cs
+++ b/StatsCalculator/StatsCalculatorBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using UnityEditorInternal;
 #if !UNITY_2019_1_OR_NEWER
@@ -140,3 +141,4 @@ namespace ProfilerDataExporter
         protected abstract float AggregateValues(IList<float> values);
     }
 }
+#endif

--- a/StatsCalculator/StatsCalculatorProvider.cs
+++ b/StatsCalculator/StatsCalculatorProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -26,3 +27,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/StatsCalculator/SumStatsCalculator.cs
+++ b/StatsCalculator/SumStatsCalculator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 
 namespace ProfilerDataExporter
 {
@@ -15,3 +16,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/UnityWrappers/GUIClip.cs
+++ b/UnityWrappers/GUIClip.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.Reflection;
 using UnityEngine;
@@ -36,3 +37,4 @@ namespace ProfilerDataExporter
 		}
 	}
 }
+#endif

--- a/UnityWrappers/SplitterGUILayout.cs
+++ b/UnityWrappers/SplitterGUILayout.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -192,3 +193,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/UnityWrappers/SplitterState.cs
+++ b/UnityWrappers/SplitterState.cs
@@ -28,7 +28,7 @@ namespace ProfilerDataExporter
             BindingFlags.DeclaredOnly |
             BindingFlags.Public | BindingFlags.NonPublic |
             BindingFlags.Instance | BindingFlags.CreateInstance, null, null, new object[] { relativeSizes, minSizes, maxSizes });
-            realSizes = (int[])RealSizesInfo.GetValue(splitter);
+            realSizes = Array.ConvertAll((float[])RealSizesInfo.GetValue(splitter), x => (int)x);
         }
 
         public SplitterState(object splitter)
@@ -69,10 +69,19 @@ namespace ProfilerDataExporter
         {
             get
             {
-                return (int)SplitterStateType.InvokeMember("splitSize",
+                var splitSize = SplitterStateType.InvokeMember("splitSize",
                     BindingFlags.DeclaredOnly |
                     BindingFlags.Public | BindingFlags.NonPublic |
                     BindingFlags.Instance | BindingFlags.GetField, null, splitter, null);
+                    
+                if (splitSize is int)
+                {
+                    return (int)splitSize;
+                }
+                else
+                {
+                    return 0;
+                }
             }
         }
         public float[] relativeSizes

--- a/UnityWrappers/SplitterState.cs
+++ b/UnityWrappers/SplitterState.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -144,3 +145,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif

--- a/Utils/ByteSize.cs
+++ b/Utils/ByteSize.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Globalization;
 
 namespace ByteSizeLib
@@ -407,3 +408,4 @@ namespace ByteSizeLib
         }
     }
 }
+#endif

--- a/Utils/TableGUILayout.cs
+++ b/Utils/TableGUILayout.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -65,3 +66,4 @@ namespace ProfilerDataExporter
         }
     }
 }
+#endif


### PR DESCRIPTION
Some types on the values the methods from the Unity library have changed with the latest versions. With this small fix the exporter works with the new version of the profiler.